### PR TITLE
feat: add owner and repo to labels for notification event in argo cm

### DIFF
--- a/argo-config/argocd-notifications-cm.yaml
+++ b/argo-config/argocd-notifications-cm.yaml
@@ -21,7 +21,9 @@ data:
               "configurationChange": {},
               "labels": {
                 "version": "{{.app.status.sync.revision}}",
-                "servicename": "{{.app.metadata.name}}"
+                "servicename": "{{.app.metadata.name}}",
+                "owner": "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}",
+                "repository": "{{.app.spec.source.repoURL}}"
               },
               "project": "{{.app.metadata.labels.keptnProject}}",
               "service": "{{.app.metadata.labels.keptnService}}",
@@ -47,6 +49,8 @@ data:
               "project": "{{.app.metadata.labels.keptnProject}}",
               "service": "{{.app.metadata.labels.keptnService}}",
               "stage": "{{.app.metadata.labels.stage}}",
+              "owner": "{{(call .repo.GetCommitMetadata .app.status.sync.revision).Author}}",
+              "repository": "{{.app.spec.source.repoURL}}",
               "result": "pass"
             },
             "source": "argocd",


### PR DESCRIPTION
Add owner and repo to labels for notification event in ArgoCD config map

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>